### PR TITLE
fix: default value for files arg

### DIFF
--- a/bin/command-line-definitions.ts
+++ b/bin/command-line-definitions.ts
@@ -9,7 +9,7 @@ export const argDefinitions: Array<CommandLineDefinition> = [
         alias: 'f',
         type: String,
         defaultOption: true,
-        defaultValue: '**/*.sym',
+        defaultValue: '**/*.so',
         typeLabel: '{underline string} (optional)',
         description: 'Glob pattern that specifies a set of android binary files to upload. Defaults to \'**/*.so\'',
     },


### PR DESCRIPTION
### Description

Copy pasta from symbol-upload

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
