### PR TITLE
fix: run dump_syms on windows

### DIFF
--- a/src/dump-syms.ts
+++ b/src/dump-syms.ts
@@ -4,6 +4,7 @@ import { platform } from 'node:os';
 import { promisify } from 'node:util';
 import { constants } from 'node:buffer';
 import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 const exec = promisify(child_process.exec);
 const maxBuffer = constants.MAX_LENGTH
 
@@ -30,7 +31,7 @@ export class DumpSyms {
             return platformSpecificFileName;
         }
 
-        const pathToDumpSyms = `./dist/bin/${platformSpecificFileName}`;
+        const pathToDumpSyms = join('.', 'dist', 'bin', platformSpecificFileName);
 
         if (!existsSync(pathToDumpSyms)) {
             throw new Error(`Could not find ${platformSpecificFileName}!`);


### PR DESCRIPTION
### Description

Join paths in a platform independent way.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
